### PR TITLE
fix/removing-unnecessary-code

### DIFF
--- a/cta.js
+++ b/cta.js
@@ -78,9 +78,6 @@ function checkCta() {
         }
       } catch (err) {
         console.log("Cannot locate #gis-cta. Forcing clerkIsAvailable()");
-        console.log(
-          "If you see clerkIsAvailable is not defined in the console, then script is not injected"
-        );
         clerkIsAvailable();
         return;
       }


### PR DESCRIPTION
Removing the console.log - as it is redundant - that states:

"If you see clerkIsAvailable is not defined in the console, then script is not injected"